### PR TITLE
start anew, add precise transformations

### DIFF
--- a/src/components/paint-editor/paint-editor.css
+++ b/src/components/paint-editor/paint-editor.css
@@ -19,6 +19,7 @@
 .editor-container-top {
     border-bottom: 1px dashed $ui-pane-border;
     padding-bottom: calc(2 * $grid-unit);
+    width: min-content;
 }
 
 .top-align-row {

--- a/src/components/paint-editor/paint-editor.jsx
+++ b/src/components/paint-editor/paint-editor.jsx
@@ -33,6 +33,7 @@ import SelectMode from '../../containers/select-mode.jsx';
 import StrokeColorIndicatorComponent from '../../containers/stroke-color-indicator.jsx';
 import StrokeWidthIndicatorComponent from '../../containers/stroke-width-indicator.jsx';
 import TextMode from '../../containers/text-mode.jsx';
+import PreciseTrans from '../../containers/precise-trans.jsx';
 
 import Formats, {isBitmap, isVector} from '../../lib/format';
 import styles from './paint-editor.css';
@@ -75,6 +76,12 @@ const PaintEditorComponent = props => (
                         onUpdateImage={props.onUpdateImage}
                         onUpdateName={props.onUpdateName}
                         width={props.width}
+                    />
+                    {/* Precise transformation variables */}
+                    <PreciseTrans
+                        onUpdateImage={props.onUpdateImage}
+                        imageId={props.imageId}
+                        image={props.image}
                     />
                 </div>
                 {/* Second Row */}

--- a/src/components/precise-trans/precise-trans.css
+++ b/src/components/precise-trans/precise-trans.css
@@ -1,0 +1,13 @@
+@import "../../css/colors.css";
+@import "../../css/units.css";
+
+.inputs {
+    padding-left: calc(2 * $grid-unit);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.numeral-input {
+    width: 3rem;
+}

--- a/src/components/precise-trans/precise-trans.jsx
+++ b/src/components/precise-trans/precise-trans.jsx
@@ -1,0 +1,47 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import BufferedInputHOC from '../forms/buffered-input-hoc.jsx';
+import Input from '../forms/input.jsx';
+import InputGroup from '../input-group/input-group.jsx';
+import Label from '../forms/label.jsx';
+import styles from './precise-trans.css';
+
+import propTypes from 'prop-types';
+
+const BufferedInput = BufferedInputHOC(Input);
+
+const PreciseTransComp = props => {
+    return (
+        <div className={styles.inputs}>
+            <InputGroup>
+                <Label text={"x"}>
+                    <BufferedInput
+                        className={styles.numeralInput}
+                        type="number"
+                        value={Math.floor(props.x)}
+                        onSubmit={props.onTransXChange}
+                    />
+                </Label>
+                <Label text={"y"}>
+                    <BufferedInput
+                        className={styles.numeralInput}
+                        type="number"
+                        value={Math.floor(props.y)}
+                        onSubmit={props.onTransYChange}
+                    />
+                </Label>
+            </InputGroup>
+        </div>
+    );
+};
+
+PreciseTransComp.propTypes = {
+    onTransXChange: PropTypes.func.isRequired,
+    onTransYChange: PropTypes.func.isRequired,
+    x: propTypes.number,
+    y: propTypes.number,
+};
+
+export default (PreciseTransComp);

--- a/src/components/precise-trans/precise-trans.jsx
+++ b/src/components/precise-trans/precise-trans.jsx
@@ -8,15 +8,13 @@ import InputGroup from '../input-group/input-group.jsx';
 import Label from '../forms/label.jsx';
 import styles from './precise-trans.css';
 
-import propTypes from 'prop-types';
-
 const BufferedInput = BufferedInputHOC(Input);
 
 const PreciseTransComp = props => {
     return (
         <div className={styles.inputs}>
             <InputGroup>
-                <Label text={"x"}>
+                <Label text={'x'}>
                     <BufferedInput
                         className={styles.numeralInput}
                         type="number"
@@ -24,7 +22,7 @@ const PreciseTransComp = props => {
                         onSubmit={props.onTransXChange}
                     />
                 </Label>
-                <Label text={"y"}>
+                <Label text={'y'}>
                     <BufferedInput
                         className={styles.numeralInput}
                         type="number"
@@ -41,7 +39,7 @@ PreciseTransComp.propTypes = {
     onTransXChange: PropTypes.func.isRequired,
     onTransYChange: PropTypes.func.isRequired,
     x: propTypes.number,
-    y: propTypes.number,
+    y: propTypes.number
 };
 
 export default (PreciseTransComp);

--- a/src/containers/precise-trans.jsx
+++ b/src/containers/precise-trans.jsx
@@ -1,0 +1,96 @@
+import paper from '@turbowarp/paper';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import PreciseTransComp from '../components/precise-trans/precise-trans.jsx';
+
+import {redrawSelectionBox} from '../reducers/selected-items';
+
+import { getSelectedRootItems } from '../helper/selection';
+import bindAll from 'lodash.bindall';
+import Modes from '../lib/modes';
+
+class PreciseTrans extends React.Component {
+    constructor(props) {
+        super(props);
+        bindAll(this, [
+            'onTransXChange',
+            'onTransYChange',
+            'translateSelection',
+            'updateExposedBounds'
+        ]);
+    }
+
+    updateExposedBounds(axis) {
+        const selected = getSelectedRootItems();
+        if (selected.length === 0) return;
+        let rect;
+        for (const item of selected) {
+            if (rect) {
+                rect = rect.unite(item.bounds);
+            } else {
+                rect = item.bounds;
+            }
+        }
+        switch (axis) {
+            case "x":
+                return rect.center._x;
+            case "y":
+                return rect.center._y;
+        }
+        return;
+    }
+
+    translateSelection(translation) {
+        const selected = getSelectedRootItems();
+        if (translation) {
+            for (const item of selected) {
+                item.translate(translation);
+            }
+            this.props.redrawSelectionBox();
+            this.props.onUpdateImage();
+        }
+    }
+
+    // to do: compress these into one function
+    onTransXChange(delta) {
+        this.translateSelection(new paper.Point(delta - this.updateExposedBounds("x"), 0));
+    }
+    onTransYChange(delta) {
+        this.translateSelection(new paper.Point(0, delta - this.updateExposedBounds("y")));
+    }
+
+    render() {
+        return (this.props.mode === Modes.SELECT ?
+            < PreciseTransComp
+                x={this.updateExposedBounds("x") ?? 0}
+                y={this.updateExposedBounds("y") ?? 0}
+                onTransXChange={this.onTransXChange}
+                onTransYChange={this.onTransYChange}
+            />
+            : <div></div>)
+    }
+}
+
+PreciseTrans.propTypes = {
+    onUpdateImage: PropTypes.func.isRequired,
+    redrawSelectionBox: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+    mode: state.scratchPaint.mode,
+    // selectedItems is unused, but it being a property updates the component whenever a selection is updated.
+    selectedItems: state.scratchPaint.selectedItems,
+});
+
+const mapDispatchToProps = dispatch => ({
+    redrawSelectionBox: () => {
+        dispatch(redrawSelectionBox());
+    },
+});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(PreciseTrans);

--- a/src/hocs/update-image-hoc.jsx
+++ b/src/hocs/update-image-hoc.jsx
@@ -135,8 +135,9 @@ const UpdateImageHOC = function (WrappedComponent) {
             }
             const guideLayers = hideGuideLayers(true /* includeRaster */);
 
-            // Export at 0.5x
-            scaleWithStrokes(paper.project.activeLayer, .5, new paper.Point());
+            // Commenting this out has somewhat broken SVG exporting-- SVG images now export at double the size. I'm sure there's a better solution than what was implemented before.
+
+            // scaleWithStrokes(paper.project.activeLayer, .5, new paper.Point());
 
             const bounds = paper.project.activeLayer.drawnBounds;
 
@@ -156,7 +157,7 @@ const UpdateImageHOC = function (WrappedComponent) {
                 }),
                 centerX,
                 centerY);
-            scaleWithStrokes(paper.project.activeLayer, 2, new paper.Point());
+            // scaleWithStrokes(paper.project.activeLayer, 2, new paper.Point());
             paper.project.activeLayer.applyMatrix = true;
 
             showGuideLayers(guideLayers);


### PR DESCRIPTION
Things were getting kind of hectic with the old branch, so I've wiped just about everything (rather, put them in branches for safekeeping) and used what I learned to start again.

This PR implements an early version of Precise Transformations, a system which will allow you to edit certain properties of items and groups, such as position, rotation, and scale, via numbers, rather than having to eyeball it.